### PR TITLE
Add null primitive type

### DIFF
--- a/json-from-schema.js
+++ b/json-from-schema.js
@@ -143,6 +143,10 @@ var _generators = {
     return !!_.random(1);
   }
 
+  , 'null': function null_() {
+    return null;
+  }
+
   , '_format': function _format(schema, options) {
     var format = schema.format;
     if(this._formatters[format]) {

--- a/test/json-from-schema-test.js
+++ b/test/json-from-schema-test.js
@@ -195,6 +195,10 @@ describe("JSON from schema", function() {
       gen._generators.boolean().should.be.a('boolean');
     });
 
+    it('should generate nulls', function () {
+      should.equal(gen._generators.null(), null);
+    });
+
     it('should generate numbers', function () {
       var schema = {type: 'number', minimum: 13.5, maximum: 22.6};
       var nums = _.times(20, function () {


### PR DESCRIPTION
The JSON Schema v4 spec has a 'null' primitive type. This PR adds a null type generator.

http://json-schema.org/latest/json-schema-core.html#anchor8